### PR TITLE
scripts/common.sh: add overlayfs EROOT workaround

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -42,8 +42,9 @@ set-sysroot() {
 
 cross-emerge() {
 	# Unfortunately, overlays can't have NFS layers.
+	# Also, overlayfs does not stack on overlayfs (e.g. inside docker containers).
 	case "$(stat -f -c %T "${EROOT}"/etc/portage)" in
-	nfs)
+	overlayfs|nfs)
 		"${HOST}-emerge" "${@}" ;;
 	*)
 		mkdir -p "${EROOT}"/mnt/workdir || exit $?


### PR DESCRIPTION
This change adds overlayfs to the list of filesystems that cannot have an overlayfs mounted, just like NFS.
This fixes an issue with EROOT being on an overlayfs, e.g. when running cross-boss inside a docker container.